### PR TITLE
Add flake input staleness checker

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,16 +68,49 @@
             platforms = platforms.linux;
           };
         };
+
+        # Flake input checker: compares locked revs against upstream via git ls-remote
+        waybar-nixos-updates-inputs = pkgs.stdenv.mkDerivation {
+          pname = "waybar-nixos-updates-inputs";
+          version = "1.0.0";
+          src = ./.;
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out/bin
+            cp input-checker $out/bin/input-checker
+            chmod +x $out/bin/input-checker
+            wrapProgram $out/bin/input-checker \
+              --prefix PATH : ${pkgs.lib.makeBinPath [
+                pkgs.coreutils
+                pkgs.git
+                pkgs.jq
+              ]}
+            runHook postInstall
+          '';
+          meta = with pkgs.lib; {
+            description = "Flake input staleness checker for Waybar";
+            homepage = "https://github.com/guttermonk/waybar-nixos-updates";
+            license = licenses.mit;
+            platforms = platforms.linux;
+          };
+        };
       in
       {
         packages = {
           default = waybar-nixos-updates;
           waybar-nixos-updates = waybar-nixos-updates;
+          inputs = waybar-nixos-updates-inputs;
         };
         
         apps.default = flake-utils.lib.mkApp {
           drv = waybar-nixos-updates;
           name = "update-checker";
+        };
+
+        apps.inputs = flake-utils.lib.mkApp {
+          drv = waybar-nixos-updates-inputs;
+          name = "input-checker";
         };
       }) // {
         # Home-Manager module

--- a/input-checker
+++ b/input-checker
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# Flake Input Checker for Waybar
+# Compares locked flake input revisions against upstream using git ls-remote.
+# Runs in seconds — no nix evaluation or builds required.
+#
+# Checks each GitHub input in flake.lock against its tracked branch.
+# Inputs pinned to a specific commit (original.rev set) are skipped.
+
+# ===== Configuration =====
+FLAKE_DIR="${FLAKE_DIR:-$HOME/.config/nixos}"
+UPDATE_INTERVAL="${UPDATE_INTERVAL:-3599}"
+CACHE_DIR="${CACHE_DIR:-$HOME/.cache}"
+STATE_FILE="$CACHE_DIR/nix-update-input-state"
+LAST_RUN_FILE="$CACHE_DIR/nix-update-input-last-run"
+LAST_RUN_TOOLTIP="$CACHE_DIR/nix-update-input-tooltip"
+
+# ===== Initialize =====
+mkdir -p "$CACHE_DIR"
+[ -f "$STATE_FILE" ] || echo "0" > "$STATE_FILE"
+[ -f "$LAST_RUN_FILE" ] || echo "0" > "$LAST_RUN_FILE"
+[ -f "$LAST_RUN_TOOLTIP" ] || echo "All inputs up to date" > "$LAST_RUN_TOOLTIP"
+
+output_json() {
+    echo "{ \"text\":\"$1\", \"alt\":\"$2\", \"tooltip\":\"$3\" }"
+}
+
+check_flake_inputs() {
+    local flake_lock="$FLAKE_DIR/flake.lock"
+    [[ ! -f "$flake_lock" ]] && return 1
+
+    local count=0
+    local tooltip=""
+
+    while IFS=$'\t' read -r name owner repo rev ref last_modified; do
+        local remote_ref
+        [[ "$ref" == "HEAD" ]] && remote_ref="HEAD" || remote_ref="refs/heads/$ref"
+
+        local latest
+        latest=$(GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="" git ls-remote \
+            "https://github.com/$owner/$repo" "$remote_ref" 2>/dev/null | cut -f1)
+
+        if [[ -n "$latest" && "$latest" != "$rev" ]]; then
+            count=$((count + 1))
+            local locked_date
+            locked_date=$(date -d "@$last_modified" +%Y-%m-%d 2>/dev/null || echo "?")
+            [[ -n "$tooltip" ]] && tooltip+="\\n"
+            tooltip+="$name (locked: $locked_date)"
+        fi
+    done < <(jq -r '
+        . as $root |
+        $root.nodes.root.inputs | to_entries[] |
+        select(.value | type == "string") |
+        {name: .key, node: $root.nodes[.value]} |
+        select(.node.locked.type == "github") |
+        select(.node.original.rev == null) |
+        [.name, .node.original.owner, .node.original.repo, .node.locked.rev,
+         (.node.original.ref // "HEAD"), (.node.locked.lastModified | tostring)] |
+        @tsv
+    ' "$flake_lock")
+
+    echo "$count" > "$STATE_FILE"
+    echo "$(date +%s)" > "$LAST_RUN_FILE"
+
+    if [ "$count" -eq 0 ]; then
+        echo "All inputs up to date" > "$LAST_RUN_TOOLTIP"
+    else
+        echo "$tooltip" > "$LAST_RUN_TOOLTIP"
+    fi
+}
+
+# ===== Main =====
+updates=$(cat "$STATE_FILE" 2>/dev/null || echo "0")
+last_run=$(cat "$LAST_RUN_FILE" 2>/dev/null || echo "0")
+current_time=$(date +%s)
+
+if [ $((current_time - last_run)) -gt "$UPDATE_INTERVAL" ]; then
+    if check_flake_inputs; then
+        updates=$(cat "$STATE_FILE" 2>/dev/null || echo "0")
+    else
+        output_json "?" "error" "Input check failed"
+        exit 0
+    fi
+fi
+
+if [ "$updates" -ne 0 ] 2>/dev/null; then
+    tooltip=$(cat "$LAST_RUN_TOOLTIP" 2>/dev/null || echo "$updates inputs behind")
+    output_json "$updates" "has-updates" "$tooltip"
+else
+    output_json "0" "updated" "All inputs up to date"
+fi


### PR DESCRIPTION
Adds `input-checker` — parses `flake.lock` and runs `git ls-remote` against each GitHub input to detect stale locks. No nix evaluation or builds; runs in seconds.

- Commit-pinned inputs are skipped
- Tooltip shows each stale input with its lock date
- New flake outputs: `packages.<system>.inputs`, `apps.<system>.inputs`
- Deps: `git`, `jq`, `coreutils`

Complements #5 / #6 (package version check) — this checks input freshness rather than individual package versions.