### PR TITLE
Add generated-output filters and source drift checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ When using the Home Manager module, you can configure these options:
   - `"show"`: Check and show in separate "Pinned:" section, but don't count
   - `"count"`: Check, show, and include in waybar count
   - Pinned inputs are those with `original.rev` set in flake.lock
+- `sourceChecks`: Explicit upstream policies for sources ordinary package checks cannot interpret. Each check selects `"disabled"`, `"show"`, or `"count"`; a current source (`flake-input`, `revision`, `tag`, or `local`); and either a canonical branch or release-tag policy. This covers intentional pins, fixed revisions in package expressions, local checkouts, named release lines, and forks without guessing intent.
 
 **Both modes:**
 - `nixosConfigPath`: Path to your NixOS configuration flake directory (default: `~/.config/nixos`)
@@ -198,6 +199,9 @@ When using the Home Manager module, you can configure these options:
     ```
   - In dual-channel mode, `nixosConfigPath` is scanned for `.nix` files to determine package sources, and flake refs are auto-detected from your `flake.lock`
 - `explicitPackagesOnly`: Only report updates for packages explicitly defined in your config files (default: `true` in dual-channel mode, `false` otherwise)
+- `lightweightExcludePatterns`: Store-output shell patterns ignored before version parsing (default: `[ "*-fish-completions" ]`)
+- `dryRunPreview.enable`: Update a temporary lock file and run `nix build --dry-run`, adding derivation, download, and size estimates to the tooltip without changing the update count or real lock file
+- `dryRunPreview.target`: Build target for the preview; `${hostname}` is replaced at run time
 
 **Lightweight mode features:**
 - **Home-manager packages**: Automatically detected and included (no config needed)

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ In json (if adding directly to the config file):
     "exec": "$HOME/bin/update-checker", // <--- path to script
     "signal": 12,
     "on-click": "$HOME/bin/update-checker toggle", // toggle update checking
-    "on-click-right": "rm ~/.cache/nix-update-last-run && pkill -RTMIN+12 waybar", // force an update
+    "on-click-right": "$HOME/bin/update-checker refresh", // force an update
     "interval": 3600, // refresh every hour
     "tooltip": true,
     "return-type": "json",
@@ -270,7 +270,7 @@ In nix (if adding it "the nix way" through home-manager):
   exec = "$HOME/bin/update-checker";  # Or "${pkgs.waybar-nixos-updates}/bin/update-checker" if using the flake
   signal = 12;
   on-click = "$HOME/bin/update-checker toggle";  # Toggle update checking
-  on-click-right = "rm ~/.cache/nix-update-last-run && pkill -RTMIN+12 waybar";
+  on-click-right = "$HOME/bin/update-checker refresh";  # Force an update
   interval = 3600;
   tooltip = true;
   return-type = "json";

--- a/dry-run-preview
+++ b/dry-run-preview
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+FLAKE_DIR="${FLAKE_DIR:-${NIXOS_CONFIG_PATH:-$HOME/.config/nixos}}"
+DRY_RUN_TARGET="${DRY_RUN_TARGET:-.#nixosConfigurations.$(hostname).config.system.build.toplevel}"
+
+tempdir=$(mktemp -d)
+trap 'rm -rf "$tempdir"' EXIT
+
+cp -a "$FLAKE_DIR"/. "$tempdir" || exit 1
+(
+    cd "$tempdir" || exit 1
+    nix flake update >/dev/null 2>&1 || exit 1
+    nix build --dry-run "$DRY_RUN_TARGET" 2>&1
+) | sed $'s/\033\[[0-9;]*m//g'

--- a/example-config.nix
+++ b/example-config.nix
@@ -20,7 +20,7 @@
   # Example 1b: Lightweight mode - single channel (fast, simple)
   # programs.waybar-nixos-updates = {
   #   enable = true;
-  #   mode = "lightweight";
+  #   checkMode = "lightweight";
   #   nixosConfigPath = "~/.config/nixos";  # Used for flake.lock and .nix file scanning
   #   nixpkgsChannel = "github:NixOS/nixpkgs/nixos-unstable";
   #   
@@ -32,7 +32,7 @@
   # Best for configs that use both pkgs and pkgs-unstable
   # programs.waybar-nixos-updates = {
   #   enable = true;
-  #   mode = "lightweight";
+  #   checkMode = "lightweight";
   #   nixosConfigPath = "~/.config/nixos";  # Scans .nix files here for package sources
   #   nixpkgsChannel = {
   #     # These identifiers match what you use in your nix files:
@@ -42,6 +42,34 @@
   #   };
   #   # Channels are auto-detected from flake.lock (nixpkgs and nixpkgs-unstable inputs)
   #   # explicitPackagesOnly defaults to true in dual-channel mode
+  # };
+
+  # Example 1e: Generated-output filtering, cost preview, and explicit source policies
+  # programs.waybar-nixos-updates = {
+  #   enable = true;
+  #   checkMode = "lightweight";
+  #   lightweightExcludePatterns = [ "*-fish-completions" "*-man" ];
+  #   dryRunPreview.enable = true;
+  #   sourceChecks = [
+  #     {
+  #       name = "computer-use plugin fork";
+  #       mode = "show";
+  #       current = "flake-input";
+  #       input = "computer-use";
+  #       repository = "https://github.com/upstream/computer-use";
+  #       policy = "branch";
+  #       ref = "main";
+  #     }
+  #     {
+  #       name = "fixed package release";
+  #       mode = "count";
+  #       current = "tag";
+  #       tag = "v1.4.2";
+  #       repository = "https://github.com/example/package";
+  #       policy = "tag";
+  #       tagPattern = "v1.*";
+  #     }
+  #   ];
   # };
 
   # Example 1d: With flake input staleness checking

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,7 @@
                 pkgs.nixVersions.stable
                 pkgs.libnotify
                 pkgs.git
+                pkgs.util-linux
               ]}"
             
             runHook postInstall
@@ -354,7 +355,7 @@
                   exec-on-event = false;
                   signal = 12;
                   on-click = "~/.config/waybar/scripts/update-checker toggle";
-                  on-click-right = "rm -f ~/.cache/nix-update-{state,last-run,tooltip,updating-flag} && pkill -RTMIN+12 .waybar-wrapped";
+                  on-click-right = "~/.config/waybar/scripts/update-checker refresh";
                   interval = cfg.updateInterval;
                   tooltip = true;
                   return-type = "json";

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
             mkdir -p $out/bin
             cp update-checker $out/bin/update-checker
             chmod +x $out/bin/update-checker
+            cp source-checker $out/bin/source-checker
+            chmod +x $out/bin/source-checker
             
             # Install icons
             mkdir -p $out/share/icons/waybar-nixos-updates
@@ -38,7 +40,7 @@
             
             # Wrap the script with required dependencies
             wrapProgram $out/bin/update-checker \
-              --prefix PATH : ${pkgs.lib.makeBinPath [
+              --prefix PATH : "$out/bin:${pkgs.lib.makeBinPath [
                 pkgs.coreutils
                 pkgs.findutils
                 pkgs.libnotify
@@ -52,7 +54,8 @@
                 pkgs.systemd
                 pkgs.iproute2
                 pkgs.inetutils
-              ]}
+                pkgs.git
+              ]}"
             
             runHook postInstall
           '';
@@ -83,6 +86,8 @@
             mkdir -p $out/bin
             cp lightweight-checker $out/bin/lightweight-checker
             chmod +x $out/bin/lightweight-checker
+            cp source-checker dry-run-preview $out/bin/
+            chmod +x $out/bin/source-checker $out/bin/dry-run-preview
             
             # Install icons (for notifications)
             mkdir -p $out/share/icons/waybar-nixos-updates
@@ -91,7 +96,7 @@
             fi
             
             wrapProgram $out/bin/lightweight-checker \
-              --prefix PATH : ${pkgs.lib.makeBinPath [
+              --prefix PATH : "$out/bin:${pkgs.lib.makeBinPath [
                 pkgs.coreutils
                 pkgs.findutils
                 pkgs.gnugrep
@@ -103,7 +108,8 @@
                 pkgs.jq
                 pkgs.nixVersions.stable
                 pkgs.libnotify
-              ]}
+                pkgs.git
+              ]}"
             
             runHook postInstall
           '';
@@ -176,6 +182,28 @@
             checkerBin = if isLightweight
               then "${self.packages.${pkgs.stdenv.hostPlatform.system}.lightweight}/bin/lightweight-checker"
               else "${cfg.package}/bin/update-checker";
+            sourceCheckType = types.submodule {
+              options = {
+                name = mkOption { type = types.str; description = "Display name."; };
+                mode = mkOption { type = types.enum [ "disabled" "show" "count" ]; default = "show"; };
+                current = mkOption {
+                  type = types.enum [ "flake-input" "revision" "tag" "local" ];
+                  description = "Where the configured source version comes from.";
+                };
+                input = mkOption { type = types.nullOr types.str; default = null; };
+                revision = mkOption { type = types.nullOr types.str; default = null; };
+                tag = mkOption { type = types.nullOr types.str; default = null; };
+                path = mkOption { type = types.nullOr types.str; default = null; };
+                repository = mkOption { type = types.str; description = "Canonical upstream Git repository URL."; };
+                policy = mkOption { type = types.enum [ "branch" "tag" ]; };
+                ref = mkOption { type = types.str; default = "HEAD"; };
+                tagPattern = mkOption { type = types.str; default = "*"; };
+                excludeTagPatterns = mkOption {
+                  type = types.listOf types.str;
+                  default = [ "*-alpha*" "*-beta*" "*-rc*" "*-pre*" ];
+                };
+              };
+            };
           in {
             options.programs.waybar-nixos-updates = {
               enable = mkEnableOption "waybar-nixos-updates";
@@ -274,6 +302,27 @@
                   false otherwise. Set explicitly to override the default.
                 '';
               };
+
+              lightweightExcludePatterns = mkOption {
+                type = types.listOf types.str;
+                default = [ "*-fish-completions" ];
+                description = "Shell patterns for generated store outputs ignored before lightweight version parsing.";
+              };
+
+              dryRunPreview = {
+                enable = mkEnableOption "a non-mutating update build-cost preview in lightweight mode";
+                target = mkOption {
+                  type = types.str;
+                  default = ".#nixosConfigurations.\${hostname}.config.system.build.toplevel";
+                  description = "Flake target to preview; literal \${hostname} is replaced at run time.";
+                };
+              };
+
+              sourceChecks = mkOption {
+                type = types.listOf sourceCheckType;
+                default = [ ];
+                description = "Explicit checks for fixed revisions, release tags, local checkouts, forks, and flake input policies.";
+              };
               
               inputChecker = {
                 mode = mkOption {
@@ -351,6 +400,10 @@
                   export NOTIFICATIONS_ENABLED="${if cfg.notifications then "true" else "false"}"
                   export INPUT_CHECKER_MODE="${cfg.inputChecker.mode}"
                   export INPUT_CHECKER_PINNED="${cfg.inputChecker.pinned}"
+                  export LIGHTWEIGHT_EXCLUDE_PATTERNS_JSON=${escapeShellArg (builtins.toJSON cfg.lightweightExcludePatterns)}
+                  export SOURCE_CHECKS_JSON=${escapeShellArg (builtins.toJSON cfg.sourceChecks)}
+                  export DRY_RUN_PREVIEW="${if cfg.dryRunPreview.enable then "true" else "false"}"
+                  export DRY_RUN_TARGET="${builtins.replaceStrings ["\${hostname}"] ["$(hostname)"] cfg.dryRunPreview.target}"
                   ${if builtins.isString cfg.nixpkgsChannel then ''
                   export NIXPKGS_CHANNEL="${cfg.nixpkgsChannel}"
                   ${if cfg.explicitPackagesOnly != null then ''
@@ -375,6 +428,7 @@
                   export NOTIFICATIONS_ENABLED="${if cfg.notifications then "true" else "false"}"
                   export INPUT_CHECKER_MODE="${cfg.inputChecker.mode}"
                   export INPUT_CHECKER_PINNED="${cfg.inputChecker.pinned}"
+                  export SOURCE_CHECKS_JSON=${escapeShellArg (builtins.toJSON cfg.sourceChecks)}
                   exec ${checkerBin} "$@"
                 '';
               };

--- a/input-checker
+++ b/input-checker
@@ -269,7 +269,6 @@ if [ -f "$INPUT_UPDATE_FLAG" ]; then
 fi
 
 if [ $((current_time - last_run)) -gt "$UPDATE_INTERVAL" ]; then
-</thinking>
     if run_checks; then
         updates=$(cat "$STATE_FILE" 2>/dev/null || echo "0")
     else

--- a/lightweight-checker
+++ b/lightweight-checker
@@ -68,6 +68,7 @@ TOGGLE_FILE="$CACHE_DIR/nix-update-toggle"
 PACKAGE_SOURCES_CACHE="$CACHE_DIR/nix-update-package-sources.json"
 FLAKE_LOCK_HASH_FILE="$CACHE_DIR/nix-update-flake-lock-hash"
 UPDATING_FLAG="$CACHE_DIR/nix-update-updating-flag"
+CHECK_LOCK_FILE="$CACHE_DIR/nix-update-check.lock"
 EXPLICIT_PACKAGES_CACHE="$CACHE_DIR/nix-update-explicit-packages.txt"
 
 # Input checker state files
@@ -1175,6 +1176,21 @@ toggle_updates() {
     refresh_waybar
 }
 
+refresh_updates() {
+    rm -f "$LAST_RUN_FILE"
+    refresh_waybar
+}
+
+start_background_check() {
+    (
+        flock -n 9 || exit 0
+        touch "$UPDATING_FLAG"
+        check_for_updates_lightweight || true
+        rm -f "$UPDATING_FLAG"
+        refresh_waybar
+    ) 9>"$CHECK_LOCK_FILE" </dev/null >/dev/null 2>&1 &
+}
+
 # ===== Main =====
 main() {
     # Check if system was just rebuilt (via REBUILD_FLAG from update script)
@@ -1261,33 +1277,17 @@ main() {
     current_time=$(date +%s)
 
     if [ $((current_time - last_run)) -gt "$UPDATE_INTERVAL" ]; then
-        # Separating updating and updated phase (like full mode)
-        if [ -f "$UPDATING_FLAG" ]; then
-            # Second phase: actually check for updates
-            if check_for_updates_lightweight; then
-                updates=$(cat "$STATE_FILE" 2>/dev/null || echo "0")
-            else
-                output_json "?" "error" "Lightweight check failed"
-                rm -f "$UPDATING_FLAG"
-                exit 0
-            fi
-            rm -f "$UPDATING_FLAG"
+        local existing_tooltip
+        existing_tooltip=$(cat "$LAST_RUN_TOOLTIP" 2>/dev/null || "")
+        local tooltip
+        if [ "$updates" != "0" ] && [ -n "$existing_tooltip" ] && [ "$existing_tooltip" != "System updated" ]; then
+            tooltip="Checking for updates... Previous check found:\\n─────────────────────────────────────────────\\n$existing_tooltip"
         else
-            # First phase: show "updating" state and trigger re-run
-            local existing_tooltip
-            existing_tooltip=$(cat "$LAST_RUN_TOOLTIP" 2>/dev/null || "")
-            local tooltip
-            if [ "$updates" != "0" ] && [ -n "$existing_tooltip" ] && [ "$existing_tooltip" != "System updated" ]; then
-                tooltip="Checking for updates... Previous check found:\\n─────────────────────────────────────────────\\n$existing_tooltip"
-            else
-                tooltip="Checking for updates..."
-            fi
-            touch "$UPDATING_FLAG"
-            output_json "$updates" "updating" "$tooltip"
-            # Signal waybar to refresh, which will trigger second phase
-            refresh_waybar
-            exit 0
+            tooltip="Checking for updates..."
         fi
+        start_background_check
+        output_json "$updates" "updating" "$tooltip"
+        exit 0
     else
         # Throttled - show wait notification if triggered manually
         if [ -t 0 ]; then
@@ -1311,8 +1311,8 @@ main() {
 # Error handler
 trap 'echo "{ \"text\":\"?\", \"alt\":\"error\", \"tooltip\":\"Script error\" }"' ERR
 
-if [ "$1" = "toggle" ]; then
-    toggle_updates
-else
-    main
-fi
+case "${1:-}" in
+    toggle) toggle_updates ;;
+    refresh) refresh_updates ;;
+    *) main ;;
+esac

--- a/lightweight-checker
+++ b/lightweight-checker
@@ -45,6 +45,10 @@ NOTIFICATIONS_ENABLED="${NOTIFICATIONS_ENABLED:-true}"
 #   - count: Check, show in tooltip, and include in waybar count
 INPUT_CHECKER_MODE="${INPUT_CHECKER_MODE:-disabled}"
 INPUT_CHECKER_PINNED="${INPUT_CHECKER_PINNED:-disabled}"
+LIGHTWEIGHT_EXCLUDE_PATTERNS_JSON="${LIGHTWEIGHT_EXCLUDE_PATTERNS_JSON:-[\"*-fish-completions\"]}"
+SOURCE_CHECKS_JSON="${SOURCE_CHECKS_JSON:-[]}"
+DRY_RUN_PREVIEW="${DRY_RUN_PREVIEW:-false}"
+DRY_RUN_TARGET="${DRY_RUN_TARGET:-.#nixosConfigurations.$(hostname).config.system.build.toplevel}"
 
 # Filter to only packages explicitly defined in config files
 # This reduces false positives from system dependencies
@@ -777,6 +781,9 @@ collect_installed_packages() {
     # Helper to extract packages from store paths
     extract_packages() {
         while IFS= read -r entry; do
+            while IFS= read -r pattern; do
+                [[ "$entry" == $pattern ]] && continue 2
+            done < <(jq -r '.[]' <<<"$LIGHTWEIGHT_EXCLUDE_PATTERNS_JSON")
             # Skip common output suffixes that aren't the main package
             case "$entry" in *-man|*-bin|*-doc|*-info|*-dev|*-lib|*-terminfo|*-debug|*-static) continue ;; esac
             # Skip entries with "unstable" in the name (date-versioned)
@@ -1032,9 +1039,21 @@ check_for_updates_lightweight() {
             pinned_count_for_total=$pinned_count
         fi
     fi
+
+    local source_count=0
+    local source_shown=0
+    local source_tooltip=""
+    if [ "$(jq 'length' <<<"$SOURCE_CHECKS_JSON" 2>/dev/null || echo 0)" -gt 0 ]; then
+        local source_result
+        source_result=$(source-checker)
+        source_count=$(jq -r '.count' <<<"$source_result")
+        source_shown=$(jq -r '.shown' <<<"$source_result")
+        source_tooltip=$(jq -r '.tooltip' <<<"$source_result")
+        source_tooltip=${source_tooltip//$'\n'/\\n}
+    fi
     
     # Calculate total count (only items with mode="count")
-    local total_count=$((pkg_count + input_count_for_total + pinned_count_for_total))
+    local total_count=$((pkg_count + input_count_for_total + pinned_count_for_total + source_count))
     echo "$total_count" > "$STATE_FILE"
     echo "$(date +%s)" > "$LAST_RUN_FILE"
     
@@ -1043,6 +1062,8 @@ check_for_updates_lightweight() {
     [ "$pkg_count" -gt 0 ] && has_items_to_show=true
     [ "$INPUT_CHECKER_MODE" != "disabled" ] && [ "$input_count" -gt 0 ] && has_items_to_show=true
     [ "$INPUT_CHECKER_PINNED" != "disabled" ] && [ "$pinned_count" -gt 0 ] && has_items_to_show=true
+    [ "$source_shown" -gt 0 ] && has_items_to_show=true
+    [ "$DRY_RUN_PREVIEW" = "true" ] && has_items_to_show=true
     
     if [ "$has_items_to_show" = false ]; then
         echo "System updated" > "$LAST_RUN_TOOLTIP"
@@ -1056,6 +1077,7 @@ check_for_updates_lightweight() {
         [ "$pkg_count" -gt 0 ] && section_count=$((section_count + 1))
         [ "$INPUT_CHECKER_MODE" != "disabled" ] && [ "$input_count" -gt 0 ] && section_count=$((section_count + 1))
         [ "$INPUT_CHECKER_PINNED" != "disabled" ] && [ "$pinned_count" -gt 0 ] && section_count=$((section_count + 1))
+        [ "$source_shown" -gt 0 ] && section_count=$((section_count + 1))
         [ "$section_count" -gt 1 ] && has_multiple_sections=true
         
         # Build packages section
@@ -1096,6 +1118,33 @@ check_for_updates_lightweight() {
                 else
                     tooltip_text="$pinned_tooltip"
                 fi
+            fi
+        fi
+
+        if [ "$source_shown" -gt 0 ]; then
+            if [ -n "$tooltip_text" ]; then
+                tooltip_text="$tooltip_text\\n\\nSources:\\n$source_tooltip"
+            else
+                tooltip_text="Sources:\\n$source_tooltip"
+            fi
+        fi
+
+        if [ "$DRY_RUN_PREVIEW" = "true" ]; then
+            local preview
+            if preview=$(dry-run-preview); then
+                local derivations paths sizes
+                derivations=$(sed -nE 's/^these ([0-9]+) derivations? will be built:$/\1/p; s/^this derivation will be built:$/1/p' <<<"$preview" | tail -1)
+                paths=$(sed -nE 's/^these ([0-9]+) paths? will be fetched.*$/\1/p; s/^this path will be fetched.*$/1/p' <<<"$preview" | tail -1)
+                sizes=$(sed -nE 's/^these [0-9]+ paths? will be fetched \((.*)\):$/\1/p; s/^this path will be fetched \((.*)\):$/\1/p' <<<"$preview" | tail -1)
+                derivations=${derivations:-0}
+                paths=${paths:-0}
+                local cost="${derivations} derivations, ${paths} downloads"
+                [ -n "$sizes" ] && cost+=" ($sizes)"
+                [ -n "$tooltip_text" ] && tooltip_text+="\\n\\n"
+                tooltip_text+="Update cost:\\n$cost"
+            else
+                [ -n "$tooltip_text" ] && tooltip_text+="\\n\\n"
+                tooltip_text+="Update cost preview failed"
             fi
         fi
         

--- a/lightweight-checker
+++ b/lightweight-checker
@@ -1182,13 +1182,16 @@ refresh_updates() {
 }
 
 start_background_check() {
+    setsid -f "$0" check-worker </dev/null >/dev/null 2>&1
+}
+
+run_check_worker() {
     (
         flock -n 9 || exit 0
+        trap 'rm -f "$UPDATING_FLAG"; refresh_waybar' EXIT INT TERM
         touch "$UPDATING_FLAG"
         check_for_updates_lightweight || true
-        rm -f "$UPDATING_FLAG"
-        refresh_waybar
-    ) 9>"$CHECK_LOCK_FILE" </dev/null >/dev/null 2>&1 &
+    ) 9>"$CHECK_LOCK_FILE"
 }
 
 # ===== Main =====
@@ -1314,5 +1317,6 @@ trap 'echo "{ \"text\":\"?\", \"alt\":\"error\", \"tooltip\":\"Script error\" }"
 case "${1:-}" in
     toggle) toggle_updates ;;
     refresh) refresh_updates ;;
+    check-worker) run_check_worker ;;
     *) main ;;
 esac

--- a/source-checker
+++ b/source-checker
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+# Optional source-provenance checker for revisions that ordinary package and
+# flake-input checks cannot interpret without an explicit upstream policy.
+
+set -u
+
+FLAKE_DIR="${FLAKE_DIR:-${NIXOS_CONFIG_PATH:-$HOME/.config/nixos}}"
+SOURCE_CHECKS_JSON="${SOURCE_CHECKS_JSON:-[]}"
+
+json_result() {
+    jq -cn --argjson count "$1" --argjson shown "$2" --arg tooltip "$3" \
+        '{count: $count, shown: $shown, tooltip: $tooltip}'
+}
+
+remote_revision() {
+    local repository="$1"
+    local ref="$2"
+    local remote_ref="$ref"
+    [[ "$ref" == "HEAD" ]] || remote_ref="refs/heads/$ref"
+    GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="" \
+        git ls-remote "$repository" "$remote_ref" 2>/dev/null | awk 'NR == 1 { print $1 }'
+}
+
+latest_tag() {
+    local repository="$1"
+    local include_pattern="$2"
+    local excluded_json="$3"
+
+    GIT_TERMINAL_PROMPT=0 GIT_ASKPASS="" git ls-remote --tags --refs "$repository" 2>/dev/null \
+        | awk '{ sub("refs/tags/", "", $2); print $2 }' \
+        | while IFS= read -r tag; do
+            [[ "$tag" == $include_pattern ]] || continue
+            excluded=false
+            while IFS= read -r pattern; do
+                if [[ "$tag" == $pattern ]]; then
+                    excluded=true
+                    break
+                fi
+            done < <(jq -r '.[]' <<<"$excluded_json")
+            [[ "$excluded" == false ]] && printf '%s\n' "$tag"
+        done \
+        | sort -V \
+        | tail -n 1
+}
+
+flake_input_node() {
+    local input="$1"
+    jq -c --arg input "$input" '
+        . as $lock
+        | $lock.nodes.root.inputs[$input] as $reference
+        | if ($reference | type) == "array" then $reference[0] else $reference end
+        | $lock.nodes[.]
+    ' "$FLAKE_DIR/flake.lock" 2>/dev/null
+}
+
+current_value() {
+    local check="$1"
+    local current_type
+    current_type=$(jq -r '.current' <<<"$check")
+
+    case "$current_type" in
+        flake-input)
+            local node
+            node=$(flake_input_node "$(jq -r '.input' <<<"$check")") || return 1
+            if [[ "$(jq -r '.policy' <<<"$check")" == "tag" ]]; then
+                jq -r '.original.ref // empty' <<<"$node"
+            else
+                jq -r '.locked.rev // empty' <<<"$node"
+            fi
+            ;;
+        local)
+            local path
+            path=$(jq -r '.path' <<<"$check")
+            path=${path/#\~/$HOME}
+            git -C "$path" rev-parse HEAD 2>/dev/null
+            ;;
+        revision)
+            jq -r '.revision // empty' <<<"$check"
+            ;;
+        tag)
+            jq -r '.tag // empty' <<<"$check"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+main() {
+    if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$SOURCE_CHECKS_JSON"; then
+        json_result 0 0 "Invalid sourceChecks configuration"
+        return
+    fi
+
+    local count=0
+    local shown=0
+    local tooltip=""
+
+    while IFS= read -r check; do
+        local mode
+        mode=$(jq -r '.mode' <<<"$check")
+        [[ "$mode" == "disabled" ]] && continue
+
+        local name repository policy current upstream
+        name=$(jq -r '.name' <<<"$check")
+        repository=$(jq -r '.repository' <<<"$check")
+        policy=$(jq -r '.policy' <<<"$check")
+        current=$(current_value "$check")
+
+        case "$policy" in
+            branch)
+                upstream=$(remote_revision "$repository" "$(jq -r '.ref' <<<"$check")")
+                ;;
+            tag)
+                upstream=$(latest_tag \
+                    "$repository" \
+                    "$(jq -r '.tagPattern' <<<"$check")" \
+                    "$(jq -c '.excludeTagPatterns' <<<"$check")")
+                ;;
+            *)
+                upstream=""
+                ;;
+        esac
+
+        [[ -n "$current" && -n "$upstream" && "$current" != "$upstream" ]] || continue
+        shown=$((shown + 1))
+        [[ "$mode" == "count" ]] && count=$((count + 1))
+        [[ -n "$tooltip" ]] && tooltip+="\n"
+        if [[ "$policy" == "tag" ]]; then
+            tooltip+="$name ($current → $upstream)"
+        else
+            tooltip+="$name (${current:0:7} → ${upstream:0:7})"
+        fi
+    done < <(jq -c '.[]' <<<"$SOURCE_CHECKS_JSON")
+
+    json_result "$count" "$shown" "$tooltip"
+}
+
+main

--- a/update-checker
+++ b/update-checker
@@ -11,6 +11,7 @@
     # Input checker: "disabled" | "show" | "count"
     INPUT_CHECKER_MODE="${INPUT_CHECKER_MODE:-disabled}"
     INPUT_CHECKER_PINNED="${INPUT_CHECKER_PINNED:-disabled}"
+    SOURCE_CHECKS_JSON="${SOURCE_CHECKS_JSON:-[]}"
     STATE_FILE="$CACHE_DIR/nix-update-state"
     LAST_RUN_FILE="$CACHE_DIR/nix-update-last-run"
     LAST_RUN_TOOLTIP="$CACHE_DIR/nix-update-tooltip"
@@ -447,9 +448,21 @@
                 pinned_count_for_total=$pinned_count
             fi
         fi
+
+        local source_count=0
+        local source_shown=0
+        local source_tooltip=""
+        if [ "$(jq 'length' <<<"$SOURCE_CHECKS_JSON" 2>/dev/null || echo 0)" -gt 0 ]; then
+            local source_result
+            source_result=$(source-checker)
+            source_count=$(jq -r '.count' <<<"$source_result")
+            source_shown=$(jq -r '.shown' <<<"$source_result")
+            source_tooltip=$(jq -r '.tooltip' <<<"$source_result")
+            source_tooltip=${source_tooltip//$'\n'/\\n}
+        fi
         
         # Calculate total count (only items with mode="count")
-        local total_count=$((pkg_count + input_count_for_total + pinned_count_for_total))
+        local total_count=$((pkg_count + input_count_for_total + pinned_count_for_total + source_count))
         
         # Save results
         echo "$total_count" > "$STATE_FILE"
@@ -460,6 +473,7 @@
         [ "$pkg_count" -gt 0 ] && has_items_to_show=true
         [ "$INPUT_CHECKER_MODE" != "disabled" ] && [ "$input_count" -gt 0 ] && has_items_to_show=true
         [ "$INPUT_CHECKER_PINNED" != "disabled" ] && [ "$pinned_count" -gt 0 ] && has_items_to_show=true
+        [ "$source_shown" -gt 0 ] && has_items_to_show=true
         
         if [ "$has_items_to_show" = false ]; then
             echo "System updated" > "$LAST_RUN_TOOLTIP"
@@ -472,6 +486,7 @@
             [ "$pkg_count" -gt 0 ] && section_count=$((section_count + 1))
             [ "$INPUT_CHECKER_MODE" != "disabled" ] && [ "$input_count" -gt 0 ] && section_count=$((section_count + 1))
             [ "$INPUT_CHECKER_PINNED" != "disabled" ] && [ "$pinned_count" -gt 0 ] && section_count=$((section_count + 1))
+            [ "$source_shown" -gt 0 ] && section_count=$((section_count + 1))
             local has_multiple_sections=false
             [ "$section_count" -gt 1 ] && has_multiple_sections=true
             
@@ -507,6 +522,14 @@
                     else
                         final_tooltip="$pinned_tooltip"
                     fi
+                fi
+            fi
+
+            if [ "$source_shown" -gt 0 ]; then
+                if [ -n "$final_tooltip" ]; then
+                    final_tooltip="$final_tooltip\\n\\nSources:\\n$source_tooltip"
+                else
+                    final_tooltip="Sources:\\n$source_tooltip"
                 fi
             fi
             

--- a/update-checker
+++ b/update-checker
@@ -571,6 +571,12 @@
         pkill -x -RTMIN+12 .waybar-wrapped
     }
 
+    function refresh_updates() {
+        # Clear cached results and force a re-check on the next poll
+        rm -f "$STATE_FILE" "$LAST_RUN_FILE" "$LAST_RUN_TOOLTIP" "$UPDATING_FLAG"
+        refresh_waybar
+    }
+
     # ===== Main Function =====
     function main() {
         init_files
@@ -720,9 +726,8 @@
     trap 'echo "{ \"text\":\"?\", \"alt\":\"error\", \"tooltip\":\"Script error occurred\" }" >&2' ERR
     
     # Check for command-line arguments
-    if [ "$1" = "toggle" ]; then
-        toggle_updates
-    else
-        # Execute main function
-        main
-    fi
+    case "${1:-}" in
+        toggle) toggle_updates ;;
+        refresh) refresh_updates ;;
+        *) main ;;
+    esac


### PR DESCRIPTION
Adds the optional checks proposed in Discussion #10 while keeping intent explicit in Home Manager configuration.

- filters generated store outputs before lightweight version parsing, with Fish completions excluded by default
- adds per-source branch or release-tag policies for flake inputs, fixed revisions, tags, and local checkouts
- adds a lightweight dry-run cost preview using a temporary lock update
- serializes refreshes through one locked background worker so Waybar immediately shows `updating` without concurrent cache races
- removes a stray `</thinking>` token that currently breaks `input-checker` syntax

Validation: `bash -n` for all scripts, `nix flake check --no-build`, and builds of all three packages.

Closes #8
Closes #9

Discussion: https://github.com/guttermonk/waybar-nixos-updates/discussions/10